### PR TITLE
Add Console E2E heartbeat monitor

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -34,6 +34,13 @@ sites:
       - 200
     maxResponseTime: 5000
 
+  - name: Console E2E
+    url: https://console.log10x.com/status/heartbeat.json
+    expectedStatusCodes:
+      - 200
+    maxResponseTime: 5000
+    __dangerous__body_down_if_text_missing: '"status": "healthy"'
+
   # Demo Environment Health Checks
   - name: Demo Cloud Reporter
     url: https://api.log10x.com/internal/v1/demo/health/cloud/reporter

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Public status page for Log10x services, powered by [Upptime](https://upptime.js.
 | Service       | Description                                |
 | ------------- | ------------------------------------------ |
 | Console       | Main web application at console.log10x.com |
+| Console E2E   | Selenium end-to-end tests via heartbeat Lambda |
 | API           | Backend API at api.log10x.com              |
 | Auth          | Authentication service at auth.log10x.com  |
 | Documentation | Product documentation at docs.log10x.com   |


### PR DESCRIPTION
## Summary
- Adds a Console E2E monitor that polls heartbeat.json written by the e2e-heartbeat Lambda
- Marks service as down if the response does not contain status: healthy
- Updates README with the new monitored service

## Test plan
- [ ] Verify Upptime picks up the new site on next scheduled run
- [ ] Confirm status.log10x.com shows Console E2E monitor