### PR TITLE
README: point the docs link at doc.log10x.com, the plural does not resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Public status page for Log10x services, powered by [Upptime](https://upptime.js.
 | Console E2E   | Selenium end-to-end tests via heartbeat Lambda |
 | API           | Backend API at api.log10x.com                  |
 | Auth          | Authentication service at auth.log10x.com      |
-| Documentation | Product documentation at docs.log10x.com       |
+| Documentation | Product documentation at doc.log10x.com        |
 | Grafana       | Dashboards and analytics                       |
 | Demo          | Demo environment                               |
 


### PR DESCRIPTION
`docs.log10x.com` has **no DNS record** — the link fails to resolve rather than landing anywhere. The documentation is served from the **singular** `doc.log10x.com`.

```
200  https://doc.log10x.com/
000  https://docs.log10x.com/
```

A 301 from the plural is landing separately in the dotcom repo (#218), but `doc` is the canonical hostname, so this points straight at it rather than relying on the redirect.

One line, no other changes.